### PR TITLE
Prevent duplicate ID's from not creating marker

### DIFF
--- a/common/src/main/kotlin/command/commands/SetMarkerCommand.kt
+++ b/common/src/main/kotlin/command/commands/SetMarkerCommand.kt
@@ -36,15 +36,19 @@ class SetMarkerCommand(plugin: SquareMarker, commands: Commands) :
     private fun execute(context: CommandContext<Commander>) {
         val sender = context.sender as PlayerCommander
 
-        val id: Int = nextInt(9, 100000)
-
-        val iconKey = "squaremarker_marker_icon_$id"
+        var id: Int
 
         val input: String = context.get("input")
 
         var content = input
 
         var url = ""
+
+        do {
+            id = nextInt(9, 100000)
+        } while (MarkerService.markerExist(id))
+
+        val iconKey: String = "squaremarker_marker_icon_$id"
 
         if (input.contains("http")) {
             val split = input.split("http")

--- a/common/src/main/kotlin/command/commands/SetMarkerCommand.kt
+++ b/common/src/main/kotlin/command/commands/SetMarkerCommand.kt
@@ -48,7 +48,7 @@ class SetMarkerCommand(plugin: SquareMarker, commands: Commands) :
             id = nextInt(9, 100000)
         } while (MarkerService.markerExist(id))
 
-        val iconKey: String = "squaremarker_marker_icon_$id"
+        val iconKey = "squaremarker_marker_icon_$id"
 
         if (input.contains("http")) {
             val split = input.split("http")


### PR DESCRIPTION
While looking at the source code I discovered a potential issue with the ID generation where a marker wouldn't get created due to it being generated only once, and if it's a duplicate of an existing ID, the user wouldn't be notified.

I'm proposing a slightly improved way of generating new ID's to ensure each new marker will definitely get one.

However, this is still far from ideal because as more markers get generated - the longer it will take to find a unique ID, and eventually (at 100k markers) it will get into an infinite loop.

Further improvements could be to use incrementing ID's or UUID's (possibly breaking current markers), but that's not up to me to decide.

Apologies if I've done something wrong. I've not used Kotlin and Gradle before.