### PR TITLE
Fix for longstanding issue present in the latest release (for Minecraft 1.20.2) for neoforge

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -22,7 +22,14 @@ dependencies {
     api("org.incendo", "cloud-kotlin-extensions")
     compileOnly("com.google.code.gson", "gson", gsonVersion)
     compileOnly("net.kyori", "adventure-text-minimessage", adventureVersion)
-    compileOnly("net.kyori", "adventure-text-logger-slf4j", adventureVersion)
+
+    // Temp fix for longstanding neoforge incompatibility
+    api("net.kyori", "adventure-text-logger-slf4j", adventureVersion) {
+        exclude("net.kyori")
+        exclude("org.slf4j")
+    }
+    compileOnly("org.slf4j", "slf4j-api", "1.7.36")
+
     api(platform("org.spongepowered:configurate-bom:$configurateVersion"))
     api("org.spongepowered:configurate-yaml")
 }


### PR DESCRIPTION
Fix for longstanding issue present in the latest release (for Minecraft 1.20.2) for neoforge.

Fix is not elegant/ideal, but given it works for all platforms including neoforge which has no adventure support natively/via a platform integration, I believe this would be worthwhile in case any neoforge users wish to use squaremarker!

[Issue #28 ](https://github.com/SentixDev/squaremarker/issues/28)